### PR TITLE
Add a RK2 time stepper

### DIFF
--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -15,12 +15,20 @@ void RungeKutta2Stepper::doStep(OceanState *State, Real Time,
    const int CurLevel  = 0;
    const int NextLevel = 1;
 
+
+   // $k_1=\Delta f(\phi_n, t_n)$
    Tend->computeAllTendencies(State, AuxState, CurLevel, Time);
+  
+   // $\phi_{n+{1\over2}}=\phi_n+{k_1 \over2}$
    updateStateByTend(State, NextLevel, State, CurLevel,  0.5*TimeStep);
 
+   // $k_2=\Delta f(\phi_n+{1\over2}, t_n+{\Delta t\over2})$
    Tend->computeAllTendencies(State, AuxState, NextLevel, Time + 0.5*TimeStep);
+
+   // $\phi_{n+1}=\phi_n+k_2$
    updateStateByTend(State, NextLevel, State, CurLevel, TimeStep);
 
+   // Update time levels (New -> Old) of prognostic variables with halo exchanges
    State->updateTimeLevels();
 }
 

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.cpp
@@ -1,0 +1,27 @@
+#include "RungeKutta2Stepper.h"
+
+namespace OMEGA {
+
+RungeKutta2Stepper::RungeKutta2Stepper(const std::string &Name,
+                                       Tendencies *Tend,
+                                       AuxiliaryState *AuxState, HorzMesh *Mesh,
+                                       Halo *MeshHalo)
+    : TimeStepper(Name, TimeStepperType::RungeKutta2, Tend, AuxState, Mesh,
+                  MeshHalo) {}
+
+void RungeKutta2Stepper::doStep(OceanState *State, Real Time,
+                                Real TimeStep) const {
+
+   const int CurLevel  = 0;
+   const int NextLevel = 1;
+
+   Tend->computeAllTendencies(State, AuxState, CurLevel, Time);
+   updateStateByTend(State, NextLevel, State, CurLevel,  0.5*TimeStep);
+
+   Tend->computeAllTendencies(State, AuxState, NextLevel, Time + 0.5*TimeStep);
+   updateStateByTend(State, NextLevel, State, CurLevel, TimeStep);
+
+   State->updateTimeLevels();
+}
+
+} // namespace OMEGA

--- a/components/omega/src/timeStepping/RungeKutta2Stepper.h
+++ b/components/omega/src/timeStepping/RungeKutta2Stepper.h
@@ -1,0 +1,18 @@
+#ifndef OMEGA_TSRK2_H
+#define OMEGA_TSRK2_H
+
+#include "TimeStepper.h"
+
+namespace OMEGA {
+
+class RungeKutta2Stepper : public TimeStepper {
+ public:
+   RungeKutta2Stepper(const std::string &Name, Tendencies *Tend,
+                      AuxiliaryState *AuxState, HorzMesh *Mesh, Halo *MeshHalo);
+
+   void doStep(OceanState *State, Real Time, Real TimeStep) const override;
+
+};
+
+} // namespace OMEGA
+#endif

--- a/components/omega/src/timeStepping/TimeStepper.cpp
+++ b/components/omega/src/timeStepping/TimeStepper.cpp
@@ -1,6 +1,7 @@
 #include "TimeStepper.h"
 #include "ForwardBackwardStepper.h"
 #include "RungeKutta4Stepper.h"
+#include "RungeKutta2Stepper.h"
 
 namespace OMEGA {
 
@@ -36,6 +37,10 @@ TimeStepper *TimeStepper::create(const std::string &Name, TimeStepperType Type,
    case TimeStepperType::RungeKutta4:
       NewTimeStepper =
           new RungeKutta4Stepper(Name, Tend, AuxState, Mesh, MeshHalo);
+      break;
+   case TimeStepperType::RungeKutta2:
+      NewTimeStepper =
+          new RungeKutta2Stepper(Name, Tend, AuxState, Mesh, MeshHalo);
       break;
    }
 

--- a/components/omega/src/timeStepping/TimeStepper.h
+++ b/components/omega/src/timeStepping/TimeStepper.h
@@ -14,7 +14,7 @@
 
 namespace OMEGA {
 
-enum class TimeStepperType { ForwardBackward, RungeKutta4 };
+enum class TimeStepperType { ForwardBackward, RungeKutta4, RungeKutta2 };
 
 class TimeStepper {
  public:

--- a/components/omega/test/timeStepping/TimeStepperTest.cpp
+++ b/components/omega/test/timeStepping/TimeStepperTest.cpp
@@ -277,6 +277,11 @@ int timeStepperTest(const std::string &MeshFile = "OmegaMesh.nc") {
    Err += testTimeStepper("ForwardBackward", TimeStepperType::ForwardBackward,
                           ExpectedOrder, ATol);
 
+   ExpectedOrder = 2;
+   ATol          = 0.1;
+   Err += testTimeStepper("RungeKutta2", TimeStepperType::RungeKutta2,
+                          ExpectedOrder, ATol);
+
    if (Err == 0) {
       LOG_INFO("TimeStepperTest: Successful completion");
    }


### PR DESCRIPTION
This PR adds Runge Kutta 2 (RK2) time stepper (midpoint method) to the existing time stepping codes.


 $k_1=\Delta f(\phi_n, t_n)$
 $k_2=\Delta f(\phi_n+{k_1\over2}, t_n+{\Delta t\over2})$
 $\phi_{n+1}=\phi_n+k_2$


Ctest for RK2 time stepper has also been added to `test/timeStepping/TimeStepperTest.cpp` with `ExpectedOrder = 2`.